### PR TITLE
Add VC id to its recommendations subject

### DIFF
--- a/src/models/CredentialEngine.ts
+++ b/src/models/CredentialEngine.ts
@@ -2,7 +2,6 @@ import { Ed25519VerificationKey2020 } from '@digitalbazaar/ed25519-verification-
 import { Ed25519Signature2020 } from '@digitalbazaar/ed25519-signature-2020';
 import * as dbVc from '@digitalbazaar/vc';
 import { v4 as uuidv4 } from 'uuid';
-import { driver as keyDriver } from '@digitalbazaar/did-method-key';
 
 import {
 	extractKeyPairFromCredential,
@@ -14,16 +13,16 @@ import {
 	generateUnsignedVolunteering,
 } from '../utils/credential.js';
 import { customDocumentLoader } from '../utils/digitalbazaar.js';
+import type { IVerifiableCredential } from '@digitalcredentials/ssi';
 import {
 	DidDocument,
 	KeyPair,
 	FormDataI,
 	RecommendationFormDataI,
-	VerifiableCredential,
 	EmploymentFormDataI,
 	PerformanceReviewFormDataI,
 	VolunteeringFormDataI,
-} from '../../types/credential.js';
+} from '../../types';
 import { saveToGoogleDrive } from '../utils/google.js';
 import { GoogleDriveStorage } from './GoogleDriveStorage.js';
 import { decodeSeed, getDidFromEnvSeed } from '../utils/decodedSeed.js';
@@ -63,7 +62,7 @@ export class CredentialEngine {
 		this.storage = storage;
 	}
 
-	private async getKeyPair(vc: VerifiableCredential) {
+	private async getKeyPair(vc: IVerifiableCredential) {
 		// Fetch all stored key pairs
 		const keyPairs = await this.storage.getAllFilesByType('KEYPAIRs');
 		if (!keyPairs || keyPairs.length === 0) {
@@ -108,7 +107,7 @@ export class CredentialEngine {
 		// The `signer` is already provided by the `Ed25519VerificationKey2020` instance
 		return keyPair;
 	};
-	private async verifyCreds(creds: VerifiableCredential[]): Promise<boolean> {
+	private async verifyCreds(creds: IVerifiableCredential[]): Promise<boolean> {
 		await Promise.all(
 			creds.map((cred) => {
 				const res = this.verifyCredential(cred);
@@ -116,6 +115,38 @@ export class CredentialEngine {
 			})
 		);
 		return true;
+	}
+
+	/**
+	 * For recommendations we need the *target VC DID/URI* (VC `id`) in the payload.
+	 * Callers may still pass a Google Drive file id; if so we resolve and extract the VC `id`.
+	 */
+	private async resolveTargetVcId(vcIdOrFileId: string): Promise<string> {
+		if (!vcIdOrFileId) throw new Error('Missing target VC reference');
+
+		// Already a DID/URI
+		if (vcIdOrFileId.startsWith('urn:') || vcIdOrFileId.startsWith('did:')) {
+			return vcIdOrFileId;
+		}
+
+		// Otherwise assume it's a Google Drive file id and resolve
+		const retrieved = await this.storage.retrieve(vcIdOrFileId);
+		if (!retrieved?.data) throw new Error(`Unable to resolve VC from file id: ${vcIdOrFileId}`);
+
+		const maybeEnvelope = retrieved.data as any;
+		const payload =
+			typeof maybeEnvelope?.body === 'string'
+				? JSON.parse(maybeEnvelope.body)
+				: maybeEnvelope?.body
+					? maybeEnvelope.body
+					: maybeEnvelope;
+
+		const resolvedId = payload?.id;
+		if (!resolvedId || typeof resolvedId !== 'string') {
+			throw new Error(`Resolved VC is missing an 'id' (from file id: ${vcIdOrFileId})`);
+		}
+
+		return resolvedId;
 	}
 
 	/**
@@ -192,8 +223,10 @@ export class CredentialEngine {
 				break;
 			case 'RECOMMENDATION':
 				if (!vcFileId) throw new Error('vcFileId is required for recommendation');
+				// Ensure the Recommendation VC references the target VC DID/URI (not a Drive file id)
+				const targetVcId = await this.resolveTargetVcId(vcFileId);
 				credential = generateUnsignedRecommendation({
-					vcId: vcFileId,
+					vcId: targetVcId,
 					recommendation: data as RecommendationFormDataI,
 					issuerDid: issuerId,
 				});
@@ -232,7 +265,7 @@ export class CredentialEngine {
 	 * @returns {Promise<boolean>} The verification result.
 	 * @throws Will throw an error if VC verification fails.
 	 */
-	public async verifyCredential(credential: VerifiableCredential): Promise<boolean> {
+	public async verifyCredential(credential: IVerifiableCredential): Promise<boolean> {
 		try {
 			const keyPair = await extractKeyPairFromCredential(credential);
 
@@ -260,7 +293,7 @@ export class CredentialEngine {
 	 * @param verifiableCredential
 	 * @returns
 	 */
-	public async createPresentation(verifiableCredential: VerifiableCredential[]) {
+	public async createPresentation(verifiableCredential: IVerifiableCredential[]) {
 		try {
 			const res = await this.verifyCreds(verifiableCredential);
 			if (!res) throw new Error('Some credentials failed verification');

--- a/src/scripts/testSkillAndRecommendation.js
+++ b/src/scripts/testSkillAndRecommendation.js
@@ -1,0 +1,114 @@
+import { CredentialEngine, GoogleDriveStorage, getVCWithRecommendations, saveToGoogleDrive } from '../../dist/index.js';
+
+/**
+ * End-to-end test script:
+ * - create DID + keypair
+ * - sign + save a "Skill VC" (regular VC) with credentialSubject.id set
+ * - sign + save a Recommendation VC that includes:
+ *   - credentialSubject.id
+ *   - credentialSubject.id = <skill vc id>
+ * - save recommendation with `vcId=<skill VC file id>` to update/create RELATIONS
+ *
+ * Requires:
+ *   GOOGLE_ACCESS_TOKEN=<oauth token with Drive access>
+ */
+
+const accessToken = process.env.GOOGLE_ACCESS_TOKEN;
+if (!accessToken) {
+	throw new Error('Missing GOOGLE_ACCESS_TOKEN env var.');
+}
+
+async function main() {
+	const storage = new GoogleDriveStorage(accessToken);
+	const engine = new CredentialEngine(storage);
+
+	// 1) Create DID + keypair
+	const { didDocument, keyPair } = await engine.createDID();
+	console.log('DID:', didDocument.id);
+
+	// 2) Create "Skill VC" (regular VC)
+	const skillFormData = {
+		expirationDate: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+		fullName: 'Omar',
+		duration: 'P1Y',
+		criteriaNarrative: 'Demonstrated skill through project work.',
+		achievementDescription: 'Skill credential used for recommendation test.',
+		achievementName: 'Skill VC Test',
+		portfolio: [{ name: 'Portfolio', url: 'https://example.com/portfolio' }],
+		evidenceLink: 'https://example.com/evidence',
+		evidenceDescription: 'Evidence for skill.',
+		credentialType: 'SkillCredential',
+		// New optional field (so VC has credentialSubject.id)
+		subjectId: didDocument.id,
+	};
+
+	const signedSkillVc = await engine.signVC({
+		data: skillFormData,
+		type: 'VC',
+		keyPair,
+		issuerId: didDocument.id,
+	});
+
+	const savedSkill = await saveToGoogleDrive({
+		storage,
+		data: signedSkillVc,
+		type: 'VC',
+	});
+
+	console.log('Saved Skill VC file:', savedSkill.id);
+	console.log('Skill VC id (credential id):', signedSkillVc.id);
+
+	// 3) Create Recommendation VC about the skill VC id
+	const recommendationFormData = {
+		expirationDate: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+		fullName: 'Omar',
+		howKnow: 'Worked together on multiple projects.',
+		recommendationText: 'Omar has consistently demonstrated strong skills and great ownership.',
+		portfolio: [{ name: 'Project', url: 'https://example.com/project' }],
+		qualifications: 'Relevant experience in the domain.',
+		explainAnswer: 'Strong execution, clear communication, reliable delivery.',
+		// New optional field (so recommendation has credentialSubject.id)
+		subjectId: didDocument.id,
+	};
+
+	const signedRecommendationVc = await engine.signVC({
+		data: recommendationFormData,
+		type: 'RECOMMENDATION',
+		keyPair,
+		issuerId: didDocument.id,
+		// Back-compat: pass the Skill VC *Drive file id* and let the engine resolve the VC DID/URI
+		vcFileId: savedSkill.id,
+	});
+
+	// Save recommendation AND link it to the skill VC's RELATIONS via the existing saveToGoogleDrive helper
+	const savedRecommendation = await saveToGoogleDrive({
+		storage,
+		data: signedRecommendationVc,
+		type: 'RECOMMENDATION',
+		// This is the Google Drive file id of the parent VC JSON file
+		vcId: savedSkill.id,
+	});
+
+	console.log('Saved Recommendation file:', savedRecommendation.id);
+
+	// 4) Verify linkage through RELATIONS
+	const linked = await getVCWithRecommendations({ vcId: savedSkill.id, storage });
+	console.log('RELATIONS recommendationIds:', linked.recommendationIds);
+
+	// 5) Verify skill VC id value in the saved recommendation payload
+	const recFile = await storage.retrieve(savedRecommendation.id);
+	const recVc = JSON.parse(recFile.data.body);
+	console.log('Recommendation credentialSubject.id:', recVc.credentialSubject?.id);
+	console.log('Expected credentialSubject.id (skill vc id):', signedSkillVc.id);
+	if (recVc?.credentialSubject?.id !== signedSkillVc.id) {
+		throw new Error(
+			`Mismatch: expected recommendation.credentialSubject.id to be "${signedSkillVc.id}" but got "${recVc?.credentialSubject?.id}"`
+		);
+	}
+}
+
+main().catch((e) => {
+	console.error(e);
+	process.exitCode = 1;
+});
+

--- a/src/utils/credential.ts
+++ b/src/utils/credential.ts
@@ -173,7 +173,7 @@ export function generateUnsignedRecommendation({
 				portfolio: 'https://schema.org/portfolio',
 			},
 		],
-		id: `urn:${generateHashedId({ id: vcId })}`,
+		id: ``,
 		type: ['VerifiableCredential', 'https://schema.org/RecommendationCredential'],
 		issuer: {
 			id: issuerDid,
@@ -182,6 +182,7 @@ export function generateUnsignedRecommendation({
 		issuanceDate,
 		expirationDate: recommendation.expirationDate,
 		credentialSubject: {
+			id: vcId,
 			name: recommendation.fullName,
 			howKnow: recommendation.howKnow,
 			recommendationText: recommendation.recommendationText,
@@ -193,6 +194,9 @@ export function generateUnsignedRecommendation({
 			})),
 		},
 	};
+
+	// Generate the hashed ID
+	unsignedRecommendation.id = 'urn:' + generateHashedId(unsignedRecommendation);
 
   return unsignedRecommendation as IVerifiableCredential;
 }

--- a/src/utils/google.ts
+++ b/src/utils/google.ts
@@ -32,10 +32,10 @@ export const getVCWithRecommendations = async ({ vcId, storage }: { vcId: string
  * @param {object} data - The data to save.
  * @param {FileType} data.type - The type of data being saved.
  * @returns {Promise<object>} - The file object saved to Google Drive.
- * @param {string} data.vcId - Optional unique identifier for the VC to link the recommendations.
+ * @param {string} data.vcId - When `type` is RECOMMENDATION, this is the Google Drive file id of the parent VC (named "VC") to link against.
  * @throws Will throw an error if the save operation fails.
  */
-export async function saveToGoogleDrive({ storage, data, type }: SaveToGooglePropsI): Promise<any> {
+export async function saveToGoogleDrive({ storage, data, type, vcId }: SaveToGooglePropsI): Promise<any> {
 	try {
 		const fileData = {
 			fileName: type === 'VC' ? 'VC' : `${type}-${Date.now()}`,
@@ -77,6 +77,25 @@ export async function saveToGoogleDrive({ storage, data, type }: SaveToGooglePro
 
 		// Save the file in the specific subfolder
 		const file = await storage.saveFile({ data: fileData, folderId: typeFolderId });
+
+		// If this is a recommendation, optionally link it to a parent VC folder via RELATIONS
+		if (type === 'RECOMMENDATION' && vcId) {
+			const parents = await storage.getFileParents(vcId);
+			const vcFolderId = Array.isArray(parents) ? parents[0] : parents;
+			if (!vcFolderId) throw new Error('Unable to resolve parent folder for vcId');
+
+			const vcFolderFiles = await storage.findFolderFiles(vcFolderId);
+			let relationsFile = vcFolderFiles.find((f: any) => f.name === 'RELATIONS');
+			if (!relationsFile) {
+				relationsFile = await storage.createRelationsFile({ vcFolderId });
+			}
+
+			await storage.updateRelationsFile({
+				relationsFileId: relationsFile.id,
+				recommendationFileId: file.id,
+			});
+		}
+
 		return file;
 	} catch (error) {
 		console.error('Error saving to Google Drive:', error);

--- a/types/Credential.d.ts
+++ b/types/Credential.d.ts
@@ -47,6 +47,11 @@ export interface FormDataI {
 	evidenceLink: string;
 	evidenceDescription: string;
 	credentialType: string;
+	/**
+	 * Optional DID/URI for the credential subject (holder).
+	 * If omitted, generators may default to the issuer DID.
+	 */
+	subjectId?: string;
 }
 
 export interface Credential {
@@ -60,6 +65,8 @@ export interface Credential {
 	issuanceDate: string;
 	expirationDate: string;
 	credentialSubject: {
+		/** DID/URI for the subject (holder). */
+		id?: string;
 		evidenceLink: string;
 		evidenceDescription: string;
 		portfolio: PortfolioItem[];
@@ -80,6 +87,11 @@ export interface RecommendationFormDataI {
 	howKnow: string;
 	explainAnswer: string;
 	portfolio: { name: string; url: string }[];
+	/**
+	 * Optional DID/URI for the recommendation subject (holder).
+	 * If omitted, generators may default to the issuer DID.
+	 */
+	subjectId?: string;
 }
 
 export interface RecommendationCredential {
@@ -93,6 +105,8 @@ export interface RecommendationCredential {
 	issuanceDate: string;
 	expirationDate: string;
 	credentialSubject: {
+		/** DID/URI (VC `id`) this recommendation is for (e.g., a Skill VC id). */
+		id: string;
 		name: string;
 		howKnow: string;
 		recommendationText: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,4 +6,5 @@ export interface DataToSaveI {
 
 export type FilesType = 'KEYPAIRs' | 'MEDIAs' | 'VCs' | 'VPs' | 'RECOMMENDATIONs' | 'DIDs' | 'RELATIONS';
 
-export * from './credential';
+// Re-export credential types (case-sensitive filesystems)
+export * from './Credential';


### PR DESCRIPTION
- Added support for linking recommendations to parent VCs in saveToGoogleDrive.
- Introduced resolveTargetVcId method to resolve VC IDs from Google Drive file IDs.
- Modified generateUnsignedRecommendation to generate hashed IDs correctly.
- Created a new test script for end-to-end testing of skill and recommendation VCs.